### PR TITLE
Changed the text of the translation buttons

### DIFF
--- a/javascript/prompt_translator.js
+++ b/javascript/prompt_translator.js
@@ -158,7 +158,7 @@ onUiLoaded(() => {
     //create buttons
     let trans_prompt_btn = document.createElement("button");
     // trans_prompt_btn.id = "trans_prompt_btn";
-    trans_prompt_btn.innerHTML = "🗚";
+    trans_prompt_btn.innerHTML = "<span style='font-size: 90%'>A</span><span style='font-size: 120%'>A</span>";
     trans_prompt_btn.className = "gr-button gr-button-lg gr-button-tool lg secondary gradio-button tool";
     // trans_prompt_btn.style.borderColor = "#e5e7eb";
     trans_prompt_btn.style.border = "none";
@@ -166,7 +166,7 @@ onUiLoaded(() => {
 
     let trans_neg_prompt_btn = document.createElement("button");
     // trans_neg_prompt_btn.id = "trans_neg_prompt_btn";
-    trans_neg_prompt_btn.innerHTML = "🗛";
+    trans_neg_prompt_btn.innerHTML = "<span style='font-size: 120%'>A</span><span style='font-size: 90%'>A</span>";
     trans_neg_prompt_btn.className = "gr-button gr-button-lg gr-button-tool lg secondary gradio-button tool";
     // trans_neg_prompt_btn.style.borderColor = "#e5e7eb";
     trans_neg_prompt_btn.style.border = "none";


### PR DESCRIPTION
Hello.

I am using this extension on a Mac and have noticed that the texts on the translate buttons do not display correctly on a Mac.

On a Mac it looks like this:
![image](https://user-images.githubusercontent.com/132233681/236136280-a886dcf5-dfd1-4230-8598-0234eb0b99a8.png)

Therefore, I have changed the texts of the translate buttons so that it will also display correctly on the Mac. I would be happy to have it merged if you like.

